### PR TITLE
Adding --align option to channel_image download

### DIFF
--- a/src/python/tmclient/api.py
+++ b/src/python/tmclient/api.py
@@ -1338,7 +1338,7 @@ class TmClient(HttpClient):
 
     def _download_channel_image(self, channel_name, plate_name,
             well_name, well_pos_y, well_pos_x,
-            cycle_index=0, tpoint=0, zplane=0, correct=True):
+            cycle_index=0, tpoint=0, zplane=0, correct=True, align = False):
         logger.info(
             'download image of experiment "%s" and channel "%s"',
             self.experiment_name, channel_name
@@ -1351,7 +1351,8 @@ class TmClient(HttpClient):
             'well_pos_y': well_pos_y,
             'tpoint': tpoint,
             'zplane': zplane,
-            'correct': correct
+            'correct': correct,
+            'align': align
         }
         channel_id = self._get_channel_id(channel_name)
         url = self._build_api_url(
@@ -1450,7 +1451,7 @@ class TmClient(HttpClient):
 
     def download_channel_image(self, channel_name, plate_name,
             well_name, well_pos_y, well_pos_x,
-            cycle_index=0, tpoint=0, zplane=0, correct=True):
+            cycle_index=0, tpoint=0, zplane=0, correct=True, align =False):
         '''Downloads a channel image.
 
         Parameters
@@ -1492,14 +1493,14 @@ class TmClient(HttpClient):
         response = self._download_channel_image(
             channel_name, plate_name, well_name, well_pos_y, well_pos_x,
             cycle_index=cycle_index, tpoint=tpoint, zplane=zplane,
-            correct=correct
+            correct=correct, align = align
         )
         data = np.frombuffer(response.content, np.uint8)
         return cv2.imdecode(data, cv2.IMREAD_UNCHANGED)
 
     def download_channel_image_file(self, channel_name, plate_name,
             well_name, well_pos_y, well_pos_x, cycle_index,
-            tpoint, zplane, correct, directory):
+            tpoint, zplane, correct, align, directory):
         '''Downloads a channel image and writes it to a `PNG` file on disk.
 
         Parameters
@@ -1522,6 +1523,8 @@ class TmClient(HttpClient):
             zero-based z-plane index
         correct: bool
             whether image should be corrected for illumination artifacts
+        align: bool
+            whether image should be aligned to the other cycles
         directory: str
             absolute path to the directory on disk where the file should be saved
 
@@ -1536,7 +1539,7 @@ class TmClient(HttpClient):
         response = self._download_channel_image(
             channel_name, plate_name, well_name, well_pos_y, well_pos_x,
             cycle_index=cycle_index, tpoint=tpoint, zplane=zplane,
-            correct=correct
+            correct=correct, align = align
         )
         data = response.content
         filename = self._extract_filename_from_headers(response.headers)

--- a/src/python/tmclient/cli.py
+++ b/src/python/tmclient/cli.py
@@ -906,3 +906,7 @@ channel_image_download_parser.add_argument(
     '--correct', action='store_true',
     help='whether image should be corrected for illumination artifacts'
 )
+channel_image_download_parser.add_argument(
+    '--align', action='store_true',
+    help='whether image should be aligned to other cycles'
+)


### PR DESCRIPTION
This adds the option to download aligned images, which is very useful for multiplexing.